### PR TITLE
include dp configs for bigym

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,8 @@ python3 train.py launch=mwm_rlbench env=rlbench/open_drawer
 python3 train.py method=act pixels=true env=rlbench/reach_target is_imitation_learning=true
 
 python3 train.py method=act launch=act_pixel_bigym env=bigym/dishwasher_close wandb.name=act_bigym_dishwasher_close batch_size=256 demos=-1
+
+python3 train.py launch=dp_pixel_bigym env=bigym/dishwasher_close
 ```
 
 ### Running existing algorithms/networks on custom environments.

--- a/robobase/cfgs/launch/dp_pixel_bigym.yaml
+++ b/robobase/cfgs/launch/dp_pixel_bigym.yaml
@@ -1,0 +1,45 @@
+# @package _global_
+
+defaults:
+  - ../env: null
+  - ../method: diffusion
+
+demos: 30
+num_pretrain_steps: 100000
+num_train_frames: 0
+eval_every_steps: 20000
+num_eval_episodes: 5
+batch_size: 256
+save_snapshot: true
+snapshot_every_n: 0
+replay_size_before_train: 500
+
+pixels: true
+frame_stack: 1
+
+is_imitation_learning: true
+
+action_repeat: 1
+action_sequence: 16
+execution_length: 1
+temporal_ensemble: true
+use_standardization: false  # Demo-based standardization for action space
+use_min_max_normalization: true  # Demo-based min-max normalization for action space
+min_max_margin: 0
+norm_obs: true
+
+update_every_steps: 1
+# logging settings
+wandb:  # weight and bias
+  use: true
+  project: dp_bigym
+  name: null
+
+
+replay:
+  nstep: 1
+
+hydra:
+  run:
+    dir: ./exp_local/pixel_act/bigym_${env.task_name}_${now:%Y%m%d%H%M%S}
+


### PR DESCRIPTION
Include a preliminary config for bigym diffusion policy. This reproduces part of the tasks, see the screenshot below.
<img width="421" alt="image" src="https://github.com/user-attachments/assets/ece2b4ad-9d97-441a-9bc9-8359942df9be" />
![eval_rollout_80000_7c609bfb5845a56fe4ad](https://github.com/user-attachments/assets/82a83c3b-aced-4b49-b952-f6f11df95f15)
![eval_rollout_80000_e063fc30d917fcae1eac](https://github.com/user-attachments/assets/23dea40e-5394-40ba-852d-fe560c6737c7)
